### PR TITLE
Fix phrase_parse call

### DIFF
--- a/sql_parser.h
+++ b/sql_parser.h
@@ -4,6 +4,10 @@
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
+#include <boost/variant.hpp>
+#include <string>
+#include <vector>
+#include <iostream>
 
 struct CompareOp : boost::spirit::qi::symbols<char, unsigned>
 {

--- a/test.cc
+++ b/test.cc
@@ -1,5 +1,10 @@
 #include "sql_parser.h"
 #include <fstream>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <cstring>
+#include <cstdlib>
 
 int main(int argc, char *argv[])
 {
@@ -32,7 +37,9 @@ int main(int argc, char *argv[])
             std::string::const_iterator begin = iter->begin();
             std::string::const_iterator end = iter->end();
             SelectSQL select_sql;
-            bool ret = phrase_parse(begin, end, sql_parser, boost::spirit::ascii::space, select_sql);
+            bool ret = boost::spirit::qi::phrase_parse(begin, end, sql_parser,
+                                                      boost::spirit::ascii::space,
+                                                      select_sql);
             if (ret && begin == end) {
                 if (print) {
                    std::cout << "phrase_parse succ. sql=" << *iter << std::endl;


### PR DESCRIPTION
## Summary
- use fully-qualified `boost::spirit::qi::phrase_parse`

## Testing
- `make`
- `./test sql.txt 1 1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68859a302238833092e68107ab1ee6c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and code formatting for improved readability and compatibility. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->